### PR TITLE
Issue #5 make elastisearch run as a normal user.

### DIFF
--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,5 +1,13 @@
 FROM java:7-jre
 
+# grab gosu for easy step-down from root
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION 1.4.4
@@ -15,7 +23,10 @@ COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 EXPOSE 9200 9300
 
 CMD ["elasticsearch"]
-

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.3.9
+ENV ELASTICSEARCH_VERSION %%VERSION%%
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/update.sh
+++ b/update.sh
@@ -5,9 +5,10 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-downloadable=$(curl -sSL 'http://www.elasticsearch.org/downloads' | sed -rn 's!.*?http://www.elasticsearch.org/downloads/[0-9]+-[0-9]+-[0-9]+/">Download v ([0-9]+\.[0-9]+\.[0-9]+)<.*!\1!gp')
+downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | sed -rn 's!.*?/downloads/past-releases/[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\1!gp')
 
 for version in "${versions[@]}"; do
 	recent=$(echo "$downloadable" | grep -m 1 "$version")
-	sed -ri -e 's/^(ENV ELASTICSEARCH_VERSION) .*/\1 '"$recent"'/' "$version/Dockerfile"
+	sed 's/%%VERSION%%/'"$recent"'/' <Dockerfile.template >"$version/Dockerfile"
+	cp -p docker-entrypoint.sh $version
 done


### PR DESCRIPTION
- Add a docker-entrypoint.sh script dropping root privileges when
  starting up elasticsearch. The script uses `gosu` to drop the
  permission
- Replace `CMD` by `ENTRYPOINT`
- Fix `update.sh` script to work with the new elastic.co site

Most update is shamelessly borrowed from PostgreSQL official image