### PR TITLE
Fix destination path to COPY user defined configuration.

### DIFF
--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
-COPY config /usr/share/elasticsearch/config
+COPY config /usr/share/elasticsearch/config/
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
-COPY config /usr/share/elasticsearch/config
+COPY config /usr/share/elasticsearch/config/
 
 VOLUME /usr/share/elasticsearch/data
 


### PR DESCRIPTION
The Dockerfile for ElasticSearch 1.4 https://github.com/docker-library/elasticsearch/blob/master/1.4/Dockerfile#L14 has a statement at line 14 that has the intention to copy all files from a local directory "config" into the container to "/usr/share/elasticsearch/config". 

Unfortunately this does not work since the destination misses a *trailing slash*. Please see https://docs.docker.com/reference/builder/#copy for more information.

Please accept my pull request https://github.com/docker-library/elasticsearch/pull/7 to fix this issue https://github.com/docker-library/elasticsearch/issues/8 . 

Thank you!