### PR TITLE
Make the privilege drop down optional

### DIFF
--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
 	exec gosu elasticsearch "$@"

--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -7,11 +7,14 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- elasticsearch "$@"
 fi
 
-# Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
+RUN_AS=${RUN_AS:-elasticsearch:elasticsearch}
+RUN_AS_USER=${RUN_AS/:*/}
+
+# Drop root privileges if we are running elasticsearch and RUN_AS is not root
+if [ "$1" = 'elasticsearch' -a  "$RUN_AS_USER" != '0' -a "$RUN_AS_USER" != 'root' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	chown -R $RUN_AS /usr/share/elasticsearch/data
+	exec gosu $RUN_AS_USER "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
 	exec gosu elasticsearch "$@"

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -7,11 +7,14 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- elasticsearch "$@"
 fi
 
-# Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
+RUN_AS=${RUN_AS:-elasticsearch:elasticsearch}
+RUN_AS_USER=${RUN_AS/:*/}
+
+# Drop root privileges if we are running elasticsearch and RUN_AS is not root
+if [ "$1" = 'elasticsearch' -a  "$RUN_AS_USER" != '0' -a "$RUN_AS_USER" != 'root' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	chown -R $RUN_AS /usr/share/elasticsearch/data
+	exec gosu $RUN_AS_USER "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
 	exec gosu elasticsearch "$@"

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -7,11 +7,14 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- elasticsearch "$@"
 fi
 
-# Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
+RUN_AS=${RUN_AS:-elasticsearch:elasticsearch}
+RUN_AS_USER=${RUN_AS/:*/}
+
+# Drop root privileges if we are running elasticsearch and RUN_AS is not root
+if [ "$1" = 'elasticsearch' -a  "$RUN_AS_USER" != '0' -a "$RUN_AS_USER" != 'root' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	chown -R $RUN_AS /usr/share/elasticsearch/data
+	exec gosu $RUN_AS_USER "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
 	exec gosu elasticsearch "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,11 +7,14 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- elasticsearch "$@"
 fi
 
-# Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' -a -z "$RUN_AS_ROOT" ]; then
+RUN_AS=${RUN_AS:-elasticsearch:elasticsearch}
+RUN_AS_USER=${RUN_AS/:*/}
+
+# Drop root privileges if we are running elasticsearch and RUN_AS is not root
+if [ "$1" = 'elasticsearch' -a  "$RUN_AS_USER" != '0' -a "$RUN_AS_USER" != 'root' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	chown -R $RUN_AS /usr/share/elasticsearch/data
+	exec gosu $RUN_AS_USER "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ RUN_AS_USER=${RUN_AS/:*/}
 if [ "$1" = 'elasticsearch' -a  "$RUN_AS_USER" != '0' -a "$RUN_AS_USER" != 'root' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R $RUN_AS /usr/share/elasticsearch/data
-	exec gosu $RUN_AS_USER "$@"
+	exec gosu $RUN_AS "$@"
 fi
 
 # As argument is not related to elasticsearch,


### PR DESCRIPTION
As in some situation, it is impossible to execute `chown` on the
data directory running elasticsearch as the `elasticsearch` user is
not possible. The entry point now supports to run elasticsearch
as `root` if the `RUN_AS_ROOT` environment variable is set to a non
empty string.

Fixes #5