### PR TITLE
sed executable overridable using SED environment variable.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 set -e
 
 SED=${SED:-sed}
-cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+cd "${0%/*}"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )

--- a/update.sh
+++ b/update.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -e
 
+SED=${SED:-sed}
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | sed -rn 's!.*?/downloads/past-releases/(elasticsearch-)?[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\2!gp')
+downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | "$SED" -rn 's!.*?/downloads/past-releases/(elasticsearch-)?[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\2!gp')
 
 for version in "${versions[@]}"; do
 	recent=$(echo "$downloadable" | grep -m 1 "$version")
-	sed 's/%%VERSION%%/'"$recent"'/' <Dockerfile.template >"$version/Dockerfile"
+	"$SED" 's/%%VERSION%%/'"$recent"'/' <Dockerfile.template >"$version/Dockerfile"
 	cp -p docker-entrypoint.sh $version
 done


### PR DESCRIPTION
BSD sed does not support _-r_ option. Thanks to this PR I can use the following command to run `update.sh`:

```
SED=gsed ./update.sh
```
