### PR TITLE
Bump Elasticsearch version to 1.5.1

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.5.0
+ENV ELASTICSEARCH_VERSION 1.5.1
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 


### PR DESCRIPTION
New version of Elasticsearch has been released today.