### PR TITLE
Fix permissions of logs directory

### DIFF
--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -4,14 +4,19 @@ set -e
 
 # Add elasticsearch as command if needed
 if [ "${1:0:1}" = '-' ]; then
-	set -- elasticsearch "$@"
+    set -- elasticsearch "$@"
 fi
 
 # Drop root privileges if we are running elasticsearch
 if [ "$1" = 'elasticsearch' ]; then
-	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+    # Change ownership of directories holding
+    # persisted data (indices and logs)
+    # so that elasticsearch can modify their content
+    for dir in data logs ; do
+        [ -d "/usr/share/elasticsearch/$dir" ] && \
+        chown -R elasticsearch:elasticsearch "/usr/share/elasticsearch/$dir"
+    done
+    exec gosu elasticsearch "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -4,14 +4,19 @@ set -e
 
 # Add elasticsearch as command if needed
 if [ "${1:0:1}" = '-' ]; then
-	set -- elasticsearch "$@"
+    set -- elasticsearch "$@"
 fi
 
 # Drop root privileges if we are running elasticsearch
 if [ "$1" = 'elasticsearch' ]; then
-	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+    # Change ownership of directories holding
+    # persisted data (indices and logs)
+    # so that elasticsearch can modify their content
+    for dir in data logs ; do
+        [ -d "/usr/share/elasticsearch/$dir" ] && \
+        chown -R elasticsearch:elasticsearch "/usr/share/elasticsearch/$dir"
+    done
+    exec gosu elasticsearch "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -4,14 +4,19 @@ set -e
 
 # Add elasticsearch as command if needed
 if [ "${1:0:1}" = '-' ]; then
-	set -- elasticsearch "$@"
+    set -- elasticsearch "$@"
 fi
 
 # Drop root privileges if we are running elasticsearch
 if [ "$1" = 'elasticsearch' ]; then
-	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+    # Change ownership of directories holding
+    # persisted data (indices and logs)
+    # so that elasticsearch can modify their content
+    for dir in data logs ; do
+        [ -d "/usr/share/elasticsearch/$dir" ] && \
+        chown -R elasticsearch:elasticsearch "/usr/share/elasticsearch/$dir"
+    done
+    exec gosu elasticsearch "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,8 +9,13 @@ fi
 
 # Drop root privileges if we are running elasticsearch
 if [ "$1" = 'elasticsearch' ]; then
-	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+    # Change ownership of directories holding
+    # persisted data (indices and logs)
+    # so that elasticsearch can modify their content
+    for dir in data logs ; do
+        [ -d "/usr/share/elasticsearch/$dir" ] && \
+        chown -R elasticsearch:elasticsearch "/usr/share/elasticsearch/$dir"
+    done
 	exec gosu elasticsearch "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Add elasticsearch as command if needed
 if [ "${1:0:1}" = '-' ]; then
-	set -- elasticsearch "$@"
+    set -- elasticsearch "$@"
 fi
 
 # Drop root privileges if we are running elasticsearch
@@ -16,7 +16,7 @@ if [ "$1" = 'elasticsearch' ]; then
         [ -d "/usr/share/elasticsearch/$dir" ] && \
         chown -R elasticsearch:elasticsearch "/usr/share/elasticsearch/$dir"
     done
-	exec gosu elasticsearch "$@"
+    exec gosu elasticsearch "$@"
 fi
 
 # As argument is not related to elasticsearch,


### PR DESCRIPTION
When logs directory /usr/share/elasticsearch/logs is mount as data volume,
then it is owned by root and elasticsearch was not allowed to write logs.

This PR modifies the Dockerfile entrypoint to properly `chown` the logs directory if available.
