### PR TITLE
Use ONBUILD when copying config folder

### DIFF
--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -35,7 +35,7 @@ RUN set -ex \
 		chown -R elasticsearch:elasticsearch "$path"; \
 	done
 
-COPY config/logging.yml /usr/share/elasticsearch/config/
+ONBUILD COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 


### PR DESCRIPTION
This enables forking off official elasticsearch images while being able to provide your own configuration.

When building a `Dockerfile` with the following contents
```
FROM elasticsearch:1.5
```
Will copy config folder from the directory of the machine it's being built on, not the config folder from the github repo. This will make it easier to use this images
