### PR TITLE
Update 1.7.1 and 1.6.2 

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.6.1
+ENV ELASTICSEARCH_VERSION 1.6.2
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.7.0
+ENV ELASTICSEARCH_VERSION 1.7.1
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 


### PR DESCRIPTION
https://www.elastic.co/blog/elasticsearch-1-7-1-and-1-6-2-released