### PR TITLE
Update to 2.0.0-rc1

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -13,7 +13,7 @@ RUN arch="$(dpkg --print-architecture)" \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_MAJOR 2.0
-ENV ELASTICSEARCH_VERSION 2.0.0~beta2
+ENV ELASTICSEARCH_VERSION 2.0.0~rc1
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 


### PR DESCRIPTION
Release note: https://www.elastic.co/blog/elasticsearch-2-0-0-rc1-released