### PR TITLE
Elasticsearch 2.1.1, 2.0.2, and 1.7.4 released

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -13,7 +13,7 @@ RUN arch="$(dpkg --print-architecture)" \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_MAJOR 2.0
-ENV ELASTICSEARCH_VERSION 2.0.1
+ENV ELASTICSEARCH_VERSION 2.0.2
 ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/2.x/debian
 
 RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -13,7 +13,7 @@ RUN arch="$(dpkg --print-architecture)" \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_MAJOR 2.1
-ENV ELASTICSEARCH_VERSION 2.1.0
+ENV ELASTICSEARCH_VERSION 2.1.1
 ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/2.x/debian
 
 RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list


### PR DESCRIPTION
https://www.elastic.co/blog/elasticsearch-2-1-0-and-2-0-1-and-1-7-4-released