### PR TITLE
Only be root when necessary, so that `--user` works

### DIFF
--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.6/docker-entrypoint.sh
+++ b/1.6/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/1.6/docker-entrypoint.sh
+++ b/1.6/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/1.7/docker-entrypoint.sh
+++ b/1.7/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/1.7/docker-entrypoint.sh
+++ b/1.7/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/2.0/docker-entrypoint.sh
+++ b/2.0/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/2.0/docker-entrypoint.sh
+++ b/2.0/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,10 +8,13 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Drop root privileges if we are running elasticsearch
-if [ "$1" = 'elasticsearch' ]; then
+# allow the container to be stated with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
 	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
-	exec gosu elasticsearch "$@"
+	
+	set -- gosu elasticsearch "$@"
+	#exec gosu elasticsearch "$BASH_SOURCE" "$@"
 fi
 
 # As argument is not related to elasticsearch,


### PR DESCRIPTION
If a user mounts a directory to `/usr/share/elasticsearch/data`, while using `--user` on the `docker run` then they are responsible to set the permissions.  This should also help OSX users when sharing a directory from the host:

```console
$ docker run -d -v /Users/...elasticsearch/:/usr/share/elasticsearch/data --user 1000:50 elasticsearch
```

resolves #14 fixes #27 fixes #69 fixes #74

Caveat: to run `elasticsearch` as `root`, you will have to skip the entrypoint.