### PR TITLE
Set docker workdir to elasticsearch root

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -46,6 +46,7 @@ VOLUME /usr/share/elasticsearch/data
 
 COPY docker-entrypoint.sh /
 
+WORKDIR /usr/share/elasticsearch
 EXPOSE 9200 9300
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["elasticsearch"]


### PR DESCRIPTION
So base image default folder is already to elasticsearch location, without need to read the Dockerfile.