### PR TITLE
Update to 2.2.1

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_MAJOR 2.2
-ENV ELASTICSEARCH_VERSION 2.2.0
+ENV ELASTICSEARCH_VERSION 2.2.1
 ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/2.x/debian
 
 RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list


### PR DESCRIPTION
Release notes: https://www.elastic.co/blog/elasticsearch-2-2-1-released