### PR TITLE
Update to 2.3.5

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 # https://packages.elasticsearch.org/GPG-KEY-elasticsearch
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 2.3.4
+ENV ELASTICSEARCH_VERSION 2.3.5
 ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/2.x/debian
 
 RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list


### PR DESCRIPTION
https://www.elastic.co/blog/elasticsearch-2-3-5-released