### PR TITLE
Update to 5.0.0-alpha5

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 # https://packages.elasticsearch.org/GPG-KEY-elasticsearch
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 5.0.0-alpha4
+ENV ELASTICSEARCH_VERSION 5.0.0-alpha5
 ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/5.x/debian
 
 RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list


### PR DESCRIPTION
https://www.elastic.co/blog/elasticsearch-5-0-0-alpha5-released