### PR TITLE
Update FROM to use the new "openjdk" image instead of the deprecated "java"

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/2046