### PR TITLE
Update to 5.0.1

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends apt-transport-https && rm -rf /var/lib/apt/lists/* \
 	&& echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/apt/sources.list.d/elasticsearch.list
 
-ENV ELASTICSEARCH_VERSION 5.0.0
+ENV ELASTICSEARCH_VERSION 5.0.1
 
 RUN set -x \
 	&& apt-get update \


### PR DESCRIPTION
https://www.elastic.co/blog/elasticsearch-5-0-1-released