### PR TITLE
Added Windows variants for v5

### DIFF
--- a/5/windows/nanoserver/Dockerfile
+++ b/5/windows/nanoserver/Dockerfile
@@ -1,0 +1,38 @@
+# escape=`
+FROM microsoft/nanoserver
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# OpenJDK - this can go when we have an official Windows OpenJDK image - see https://github.com/docker-library/openjdk/pull/88
+ENV JAVA_VERSION="1.8.0.111-3" `
+    JAVA_ZIP_VERSION="1.8.0-openjdk-1.8.0.111-3.b15" `
+    JAVA_SHA256="e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454" `    
+    JAVA_HOME="C:\openjdk"
+
+RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; `
+    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; `
+    Expand-Archive openjdk.zip -DestinationPath C:\ ; `
+    mv "C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64" 'c:\openjdk'; `
+    Remove-Item -Path openjdk.zip
+
+# Elasticsearch
+ENV ES_VERSION="5.1.1" `
+    ES_SHA1="d4b966c19c85dd2cb9a5b9750193f82f49e63717" `
+    ES_HOME="c:\elasticsearch"
+
+RUN Invoke-WebRequest -outfile elasticsearch.zip "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($env:ES_VERSION).zip" -UseBasicParsing; `
+    if ((Get-FileHash elasticsearch.zip -Algorithm sha1).Hash -ne $env:ES_SHA1) {exit 1} ; `
+    Expand-Archive elasticsearch.zip -DestinationPath C:\ ; `
+    Move-Item "c:/elasticsearch-$($env:ES_VERSION)" 'c:\elasticsearch'; `
+    Remove-Item elasticsearch.zip
+
+VOLUME c:/data
+
+# REMARKS - DNS and mount tweaks needed for Windows
+RUN Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
+    Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String    
+
+EXPOSE 9200 9300
+WORKDIR c:/elasticsearch
+COPY config ./config
+
+CMD ".\bin\elasticsearch.bat"

--- a/5/windows/nanoserver/Dockerfile
+++ b/5/windows/nanoserver/Dockerfile
@@ -11,7 +11,7 @@ ENV JAVA_VERSION="1.8.0.111-3" `
 RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; `
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; `
     Expand-Archive openjdk.zip -DestinationPath C:\ ; `
-    mv "C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64" 'c:\openjdk'; `
+    Move-Item C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64 'c:\openjdk'; `
     Remove-Item -Path openjdk.zip
 
 # Elasticsearch
@@ -22,7 +22,7 @@ ENV ES_VERSION="5.1.1" `
 RUN Invoke-WebRequest -outfile elasticsearch.zip "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($env:ES_VERSION).zip" -UseBasicParsing; `
     if ((Get-FileHash elasticsearch.zip -Algorithm sha1).Hash -ne $env:ES_SHA1) {exit 1} ; `
     Expand-Archive elasticsearch.zip -DestinationPath C:\ ; `
-    Move-Item "c:/elasticsearch-$($env:ES_VERSION)" 'c:\elasticsearch'; `
+    Move-Item c:/elasticsearch-$($env:ES_VERSION) 'c:\elasticsearch'; `
     Remove-Item elasticsearch.zip
 
 VOLUME c:/data
@@ -35,4 +35,5 @@ EXPOSE 9200 9300
 WORKDIR c:/elasticsearch
 COPY config ./config
 
+SHELL ["cmd", "/S", "/C"]
 CMD ".\bin\elasticsearch.bat"

--- a/5/windows/nanoserver/Dockerfile
+++ b/5/windows/nanoserver/Dockerfile
@@ -1,22 +1,10 @@
 # escape=`
-FROM microsoft/nanoserver
+FROM openjdk:8-jdk-nanoserver
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# OpenJDK - this can go when we have an official Windows OpenJDK image - see https://github.com/docker-library/openjdk/pull/88
-ENV JAVA_VERSION="1.8.0.111-3" `
-    JAVA_ZIP_VERSION="1.8.0-openjdk-1.8.0.111-3.b15" `
-    JAVA_SHA256="e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454" `    
-    JAVA_HOME="C:\openjdk"
-
-RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; `
-    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; `
-    Expand-Archive openjdk.zip -DestinationPath C:\ ; `
-    Move-Item C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64 'c:\openjdk'; `
-    Remove-Item -Path openjdk.zip
-
 # Elasticsearch
-ENV ES_VERSION="5.1.1" `
-    ES_SHA1="d4b966c19c85dd2cb9a5b9750193f82f49e63717" `
+ENV ES_VERSION="5.2.0" `
+    ES_SHA1="243cce802055a06e810fc1939d9f8b22ee68d227" `
     ES_HOME="c:\elasticsearch"
 
 RUN Invoke-WebRequest -outfile elasticsearch.zip "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($env:ES_VERSION).zip" -UseBasicParsing; `

--- a/5/windows/nanoserver/config/elasticsearch.yml
+++ b/5/windows/nanoserver/config/elasticsearch.yml
@@ -1,0 +1,8 @@
+network.host: 0.0.0.0
+
+# this value is required because we set "network.host"
+# be sure to modify it appropriately for a production cluster deployment
+discovery.zen.minimum_master_nodes: 1
+
+path:
+    data: g:\

--- a/5/windows/nanoserver/config/log4j2.properties
+++ b/5/windows/nanoserver/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/5/windows/windowsservercore/Dockerfile
+++ b/5/windows/windowsservercore/Dockerfile
@@ -1,0 +1,38 @@
+# escape=`
+FROM microsoft/windowsservercore
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# OpenJDK - this can go when we have an official Windows OpenJDK image - see https://github.com/docker-library/openjdk/pull/88
+ENV JAVA_VERSION="1.8.0.111-3" `
+    JAVA_ZIP_VERSION="1.8.0-openjdk-1.8.0.111-3.b15" `
+    JAVA_SHA256="e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454" `    
+    JAVA_HOME="C:\openjdk"
+
+RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; `
+    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; `
+    Expand-Archive openjdk.zip -DestinationPath C:\ ; `
+    mv "C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64" 'c:\openjdk'; `
+    Remove-Item -Path openjdk.zip
+
+# Elasticsearch
+ENV ES_VERSION="5.1.1" `
+    ES_SHA1="d4b966c19c85dd2cb9a5b9750193f82f49e63717" `
+    ES_HOME="c:\elasticsearch"
+
+RUN Invoke-WebRequest -outfile elasticsearch.zip "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($env:ES_VERSION).zip" -UseBasicParsing; `
+    if ((Get-FileHash elasticsearch.zip -Algorithm sha1).Hash -ne $env:ES_SHA1) {exit 1} ; `
+    Expand-Archive elasticsearch.zip -DestinationPath C:\ ; `
+    Move-Item "c:/elasticsearch-$($env:ES_VERSION)" 'c:\elasticsearch'; `
+    Remove-Item elasticsearch.zip
+
+VOLUME c:/data
+
+# REMARKS - DNS and mount tweaks needed for Windows
+RUN Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
+    Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String    
+
+EXPOSE 9200 9300
+WORKDIR c:/elasticsearch
+COPY config ./config
+
+CMD ".\bin\elasticsearch.bat"

--- a/5/windows/windowsservercore/Dockerfile
+++ b/5/windows/windowsservercore/Dockerfile
@@ -11,7 +11,7 @@ ENV JAVA_VERSION="1.8.0.111-3" `
 RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; `
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; `
     Expand-Archive openjdk.zip -DestinationPath C:\ ; `
-    mv "C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64" 'c:\openjdk'; `
+    Move-Item C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64 'c:\openjdk'; `
     Remove-Item -Path openjdk.zip
 
 # Elasticsearch
@@ -22,7 +22,7 @@ ENV ES_VERSION="5.1.1" `
 RUN Invoke-WebRequest -outfile elasticsearch.zip "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($env:ES_VERSION).zip" -UseBasicParsing; `
     if ((Get-FileHash elasticsearch.zip -Algorithm sha1).Hash -ne $env:ES_SHA1) {exit 1} ; `
     Expand-Archive elasticsearch.zip -DestinationPath C:\ ; `
-    Move-Item "c:/elasticsearch-$($env:ES_VERSION)" 'c:\elasticsearch'; `
+    Move-Item c:/elasticsearch-$($env:ES_VERSION) 'c:\elasticsearch'; `
     Remove-Item elasticsearch.zip
 
 VOLUME c:/data
@@ -35,4 +35,5 @@ EXPOSE 9200 9300
 WORKDIR c:/elasticsearch
 COPY config ./config
 
+SHELL ["cmd", "/S", "/C"]
 CMD ".\bin\elasticsearch.bat"

--- a/5/windows/windowsservercore/Dockerfile
+++ b/5/windows/windowsservercore/Dockerfile
@@ -1,22 +1,10 @@
 # escape=`
-FROM microsoft/windowsservercore
+FROM openjdk:8-jdk-windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# OpenJDK - this can go when we have an official Windows OpenJDK image - see https://github.com/docker-library/openjdk/pull/88
-ENV JAVA_VERSION="1.8.0.111-3" `
-    JAVA_ZIP_VERSION="1.8.0-openjdk-1.8.0.111-3.b15" `
-    JAVA_SHA256="e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454" `    
-    JAVA_HOME="C:\openjdk"
-
-RUN Invoke-WebRequest $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/java-{1}.ojdkbuild.windows.x86_64.zip' -f $env:JAVA_VERSION, $env:JAVA_ZIP_VERSION) -OutFile 'openjdk.zip' -UseBasicParsing ; `
-    if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne $env:JAVA_SHA256) {exit 1} ; `
-    Expand-Archive openjdk.zip -DestinationPath C:\ ; `
-    Move-Item C:\java-$($env:JAVA_ZIP_VERSION).ojdkbuild.windows.x86_64 'c:\openjdk'; `
-    Remove-Item -Path openjdk.zip
-
 # Elasticsearch
-ENV ES_VERSION="5.1.1" `
-    ES_SHA1="d4b966c19c85dd2cb9a5b9750193f82f49e63717" `
+ENV ES_VERSION="5.2.0" `
+    ES_SHA1="243cce802055a06e810fc1939d9f8b22ee68d227" `
     ES_HOME="c:\elasticsearch"
 
 RUN Invoke-WebRequest -outfile elasticsearch.zip "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($env:ES_VERSION).zip" -UseBasicParsing; `

--- a/5/windows/windowsservercore/config/elasticsearch.yml
+++ b/5/windows/windowsservercore/config/elasticsearch.yml
@@ -1,0 +1,8 @@
+network.host: 0.0.0.0
+
+# this value is required because we set "network.host"
+# be sure to modify it appropriately for a production cluster deployment
+discovery.zen.minimum_master_nodes: 1
+
+path:
+    data: g:\

--- a/5/windows/windowsservercore/config/log4j2.properties
+++ b/5/windows/windowsservercore/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
Signed-off-by: Elton Stoneman <elton@sixeyed.com>

Proposed Dockerfiles for building Windows variants of Elasticsearch 5 - based on Windows Server Core and Nano Server images.

There is currently no official OpenJDK image for Windows, so these images download the JDK as part of the setup, following the approach in [OpenJDK PR 88](https://github.com/docker-library/openjdk/pull/88). When we have an official image, those steps can be removed from these Dockerfiles.

Two limitations in Windows are addressed with tweaks to the registry:

- [turning off the DNS cache](https://github.com/sixeyed/elasticsearch/blob/master/5/windows/nanoserver/Dockerfile#L31) so containers can reach each other by name on the Docker network
- [mapping the data volume to a drive letter](https://github.com/sixeyed/elasticsearch/blob/master/5/windows/nanoserver/Dockerfile#L32) to overcome [the volume issue with Windows containers](https://github.com/docker/docker/issues/27537#issuecomment-271546031).

Both images build and run correctly on Windows 10 and Windows Server 2016.
