### PR TITLE
[RFC] Avoid boostrap check by not using elasticsearch in a cluster mode

### DIFF
--- a/5/alpine/config/elasticsearch.yml
+++ b/5/alpine/config/elasticsearch.yml
@@ -1,5 +1,5 @@
-network.host: 0.0.0.0
+http.host: 0.0.0.0
 
-# this value is required because we set "network.host"
-# be sure to modify it appropriately for a production cluster deployment
-discovery.zen.minimum_master_nodes: 1
+# Uncomment the following lines for a production cluster deployment
+#transport.host: 0.0.0.0
+#discovery.zen.minimum_master_nodes: 1

--- a/5/config/elasticsearch.yml
+++ b/5/config/elasticsearch.yml
@@ -1,5 +1,5 @@
-network.host: 0.0.0.0
+http.host: 0.0.0.0
 
-# this value is required because we set "network.host"
-# be sure to modify it appropriately for a production cluster deployment
-discovery.zen.minimum_master_nodes: 1
+# Uncomment the following lines for a production cluster deployment
+#transport.host: 0.0.0.0
+#discovery.zen.minimum_master_nodes: 1


### PR DESCRIPTION
Disclaimer : Even if this is a PR, it's more a RFC to understand the purpose of the elasticsearch image.

Hey,

As discussed in #98 and many others issue the current elasticsearch 5.0 version depends on setting a correct vm.max_map_count on the host having docker engine.

This is due to the fact that when inside a container it's obvious that elasticsearch must listen on correct ip and not on the localhost (otherwise it would not be accessible).

This proposal intend to clearly define what is the purpose of the official elasticsearch image : 

  * Is this image intended for production environment ?
  * Or is it intended for new developers wanting to discover elasticsearch ?

In the first case this PR can then be closed. 

In the second case this PR make sense and should be discussed. The following configuration allows to use an elasticsearch server on a docker container without having to set the `vm.max_map_count` on the host of docker and other configurations needed to have a production environment for elasticsearch (see this comment : https://github.com/elastic/elasticsearch/issues/4978#issuecomment-258842584, i have also test this configuration which works perfectly)

But it removes the possibility to have a cluster of elasticsearch, which is IMO not need when discovering elasticsearch and just want to develop around it.

The third choice would be that this image want to support both production and "easy" development environment then it could make sense to add an additional tag for this image and choose a default setting (prod or dev).

I know this has been discussed a lot, but all discussion never clarify the purpose of this image nor this possibility.
