### PR TITLE
Update elasticsearch.yml

### DIFF
--- a/5/config/elasticsearch.yml
+++ b/5/config/elasticsearch.yml
@@ -1,4 +1,4 @@
-http.host: 0.0.0.0
+network.host: 0.0.0.0
 
 # Uncomment the following lines for a production cluster deployment
 #transport.host: 0.0.0.0


### PR DESCRIPTION
Change http.host to network.host

Wrong option. Elasticsearch listen on localhost anyway. 

This image is officially deprecated in favor of [the `elasticsearch` image provided by elastic.co](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) which is available to pull via `docker.elastic.co/elasticsearch/elasticsearch:[version]` like `5.2.1`. This image will receive no further updates after 2017-06-20 (June 20, 2017). Please adjust your usage accordingly.

Elastic provides open-source support for Elasticsearch via the [elastic/elasticsearch GitHub repository](https://github.com/elastic/elasticsearch) and the Docker image via the [elastic/elasticsearch-docker GitHub repository](https://github.com/elastic/elasticsearch-docker), as well as community support via its [forums](https://discuss.elastic.co/c/elasticsearch).
