### PR TITLE
Create new "6.3" Dockerfile based on upstream's generated multi-stage Dockerfile (which is also included for simpler direct comparison)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: bash
 services: docker
 
 env:
+  - VERSION=6.3 VARIANT=
   - VERSION=5 VARIANT=
   - VERSION=5 VARIANT=alpine
   - VERSION=2.4 VARIANT=

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -1,0 +1,62 @@
+# this Dockerfile was created from Dockerfile-oss (which was generated from upstream's build system)
+
+FROM centos:7
+
+ENV ELASTIC_CONTAINER true
+
+RUN curl -s https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz | tar -C /opt -zxf -
+ENV JAVA_HOME /opt/jdk-10.0.2
+
+# Replace OpenJDK's built-in CA certificate keystore with the one from the OS
+# vendor. The latter is superior in several ways.
+# REF: https://github.com/elastic/elasticsearch-docker/issues/171
+RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-10.0.2/lib/security/cacerts
+
+RUN yum update -y && \
+    yum install -y nc unzip wget which && \
+    yum clean all
+
+RUN groupadd -g 1000 elasticsearch && \
+    adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \
+    chmod 0775 /usr/share/elasticsearch && \
+    chgrp 0 /usr/share/elasticsearch
+
+WORKDIR /usr/share/elasticsearch
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+USER 1000
+RUN set -ex; \
+    curl -fsSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.3.2.tar.gz | \
+    tar zx --strip-components=1; \
+    for esdirs in config data logs; do \
+        mkdir -p "$esdirs"; \
+    done; \
+    for PLUGIN in ingest-user-agent ingest-geoip; do \
+        elasticsearch-plugin install --batch "$PLUGIN"; \
+    done; \
+    chown -R elasticsearch:0 .; \
+    chmod -R g=u .; \
+# clean up some extra zero-byte bits left behind in /tmp
+    rm -rvf /tmp/*elasticsearch*
+USER 0
+COPY --chown=1000:0 elasticsearch.yml log4j2.properties config/
+
+COPY --chown=1000:0 bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# Openshift overrides USER and uses ones with randomly uid>1024 and gid=0
+# Allow ENTRYPOINT (and ES) to run even with a different user
+RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
+    chmod g=u /etc/passwd && \
+    chmod 0775 /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 9200 9300
+
+LABEL org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="Elastic" \
+  org.label-schema.name="elasticsearch" \
+  org.label-schema.version="6.3.2" \
+  org.label-schema.url="https://www.elastic.co/products/elasticsearch" \
+  org.label-schema.vcs-url="https://github.com/elastic/elasticsearch-docker" \
+license="Apache-2.0"
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+# Dummy overridable parameter parsed by entrypoint
+CMD ["eswrapper"]

--- a/6.3/Dockerfile-oss
+++ b/6.3/Dockerfile-oss
@@ -1,0 +1,105 @@
+################################################################################
+# This Dockerfile was generated from the template at templates/Dockerfile.j2
+#
+# Beginning of multi stage Dockerfile
+################################################################################
+
+
+################################################################################
+# Build stage 0 `prep_es_files`:
+# Extract elasticsearch artifact
+# Install required plugins
+# Set gid=0 and make group perms==owner perms
+################################################################################
+
+FROM centos:7 AS prep_es_files
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0-openjdk
+
+RUN yum install -y java-1.8.0-openjdk-headless unzip which
+
+RUN groupadd -g 1000 elasticsearch && \
+    adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
+
+WORKDIR /usr/share/elasticsearch
+
+USER 1000
+
+# Download and extract defined ES version.
+RUN curl -fsSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.3.2.tar.gz | \
+    tar zx --strip-components=1
+
+RUN set -ex && for esdirs in config data logs; do \
+        mkdir -p "$esdirs"; \
+    done
+
+# Install the ingest-{agent,geoip} modules required for Filebeat
+RUN for PLUGIN in ingest-user-agent ingest-geoip; do \
+      elasticsearch-plugin install --batch "$PLUGIN"; done
+
+COPY --chown=1000:0 elasticsearch.yml log4j2.properties config/
+
+USER 0
+
+# Set gid to 0 for elasticsearch and make group permission similar to that of user
+# This is needed, for example, for Openshift Open: https://docs.openshift.org/latest/creating_images/guidelines.html
+# and allows ES to run with an uid
+RUN chown -R elasticsearch:0 . && \
+    chmod -R g=u /usr/share/elasticsearch
+
+################################################################################
+# Build stage 1 (the actual elasticsearch image):
+# Copy elasticsearch from stage 0
+# Add entrypoint
+################################################################################
+
+FROM centos:7
+
+ENV ELASTIC_CONTAINER true
+
+RUN curl -s https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz | tar -C /opt -zxf -
+ENV JAVA_HOME /opt/jdk-10.0.2
+
+# Replace OpenJDK's built-in CA certificate keystore with the one from the OS
+# vendor. The latter is superior in several ways.
+# REF: https://github.com/elastic/elasticsearch-docker/issues/171
+RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-10.0.2/lib/security/cacerts
+
+RUN yum update -y && \
+    yum install -y nc unzip wget which && \
+    yum clean all
+
+RUN groupadd -g 1000 elasticsearch && \
+    adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \
+    chmod 0775 /usr/share/elasticsearch && \
+    chgrp 0 /usr/share/elasticsearch
+
+WORKDIR /usr/share/elasticsearch
+COPY --from=prep_es_files --chown=1000:0 /usr/share/elasticsearch /usr/share/elasticsearch
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+
+COPY --chown=1000:0 bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# Openshift overrides USER and uses ones with randomly uid>1024 and gid=0
+# Allow ENTRYPOINT (and ES) to run even with a different user
+RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
+    chmod g=u /etc/passwd && \
+    chmod 0775 /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 9200 9300
+
+LABEL org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="Elastic" \
+  org.label-schema.name="elasticsearch" \
+  org.label-schema.version="6.3.2" \
+  org.label-schema.url="https://www.elastic.co/products/elasticsearch" \
+  org.label-schema.vcs-url="https://github.com/elastic/elasticsearch-docker" \
+license="Apache-2.0"
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+# Dummy overridable parameter parsed by entrypoint
+CMD ["eswrapper"]
+
+################################################################################
+# End of multi-stage Dockerfile
+################################################################################

--- a/6.3/bin/docker-entrypoint.sh
+++ b/6.3/bin/docker-entrypoint.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -e
+
+# Files created by Elasticsearch should always be group writable too
+umask 0002
+
+run_as_other_user_if_needed() {
+    if [[ "$(id -u)" == "0" ]]; then
+        # If running as root, drop to specified UID and run command
+        exec chroot --userspec=1000 / "${@}"
+    else
+        # Either we are running in Openshift with random uid and are a member of the root group
+        # or with a custom --user
+        exec "${@}"
+    fi
+}
+
+# Allow user specify custom CMD, maybe bin/elasticsearch itself
+# for example to directly specify `-E` style parameters for elasticsearch on k8s
+# or simply to run /bin/bash to check the image
+if [[ "$1" != "eswrapper" ]]; then
+    if [[ "$(id -u)" == "0" && $(basename "$1") == "elasticsearch" ]]; then
+        # centos:7 chroot doesn't have the `--skip-chdir` option and
+        # changes our CWD.
+        # Rewrite CMD args to replace $1 with `elasticsearch` explicitly,
+        # so that we are backwards compatible with the docs
+        # from the previous Elasticsearch versions<6
+        # and configuration option D:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html#_d_override_the_image_8217_s_default_ulink_url_https_docs_docker_com_engine_reference_run_cmd_default_command_or_options_cmd_ulink
+        # Without this, user could specify `elasticsearch -E x.y=z` but
+        # `bin/elasticsearch -E x.y=z` would not work.
+        set -- "elasticsearch" "${@:2}"
+        # Use chroot to switch to UID 1000
+        exec chroot --userspec=1000 / "$@"
+    else
+        # User probably wants to run something else, like /bin/bash, with another uid forced (Openshift?)
+        exec "$@"
+    fi
+fi
+
+# Parse Docker env vars to customize Elasticsearch
+#
+# e.g. Setting the env var cluster.name=testcluster
+#
+# will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
+#
+# see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+
+declare -a es_opts
+
+while IFS='=' read -r envvar_key envvar_value
+do
+    # Elasticsearch env vars need to have at least two dot separated lowercase words, e.g. `cluster.name`
+    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ ]]; then
+        if [[ ! -z $envvar_value ]]; then
+          es_opt="-E${envvar_key}=${envvar_value}"
+          es_opts+=("${es_opt}")
+        fi
+    fi
+done < <(env)
+
+# The virtual file /proc/self/cgroup should list the current cgroup
+# membership. For each hierarchy, you can follow the cgroup path from
+# this file to the cgroup filesystem (usually /sys/fs/cgroup/) and
+# introspect the statistics for the cgroup for the given
+# hierarchy. Alas, Docker breaks this by mounting the container
+# statistics at the root while leaving the cgroup paths as the actual
+# paths. Therefore, Elasticsearch provides a mechanism to override
+# reading the cgroup path from /proc/self/cgroup and instead uses the
+# cgroup path defined the JVM system property
+# es.cgroups.hierarchy.override. Therefore, we set this value here so
+# that cgroup statistics are available for the container this process
+# will run in.
+export ES_JAVA_OPTS="-Des.cgroups.hierarchy.override=/ $ES_JAVA_OPTS"
+
+if [[ -d bin/x-pack ]]; then
+    # Check for the ELASTIC_PASSWORD environment variable to set the
+    # bootstrap password for Security.
+    #
+    # This is only required for the first node in a cluster with Security
+    # enabled, but we have no way of knowing which node we are yet. We'll just
+    # honor the variable if it's present.
+    if [[ -n "$ELASTIC_PASSWORD" ]]; then
+        [[ -f /usr/share/elasticsearch/config/elasticsearch.keystore ]] || (run_as_other_user_if_needed elasticsearch-keystore create)
+        if ! (run_as_other_user_if_needed elasticsearch-keystore list | grep -q '^bootstrap.password$'); then
+            (run_as_other_user_if_needed echo "$ELASTIC_PASSWORD" | elasticsearch-keystore add -x 'bootstrap.password')
+        fi
+    fi
+fi
+
+if [[ "$(id -u)" == "0" ]]; then
+    # If requested and running as root, mutate the ownership of bind-mounts
+    if [[ -n "$TAKE_FILE_OWNERSHIP" ]]; then
+        chown -R 1000:0 /usr/share/elasticsearch/{data,logs}
+    fi
+fi
+
+run_as_other_user_if_needed /usr/share/elasticsearch/bin/elasticsearch "${es_opts[@]}"

--- a/6.3/elasticsearch.yml
+++ b/6.3/elasticsearch.yml
@@ -1,0 +1,7 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1

--- a/6.3/log4j2.properties
+++ b/6.3/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eu
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 declare -A aliases=(
 	[2.4]='2'
@@ -55,7 +55,7 @@ join() {
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
 
-	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "ELASTICSEARCH_VERSION" { gsub(/~/, "-", $3); print $3; exit }')"
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "ELASTICSEARCH_VERSION" { gsub(/~/, "-", $3); print $3; exit } /artifacts.elastic.co\/downloads.*-oss-/ { print gensub(/^.+-oss-([0-9.]+)[.]tar.+$/, "\\1", 1); exit }')"
 
 	rcVersion="${version%-rc}"
 

--- a/update.sh
+++ b/update.sh
@@ -3,11 +3,12 @@ set -e
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-versions=( "$@" )
-if [ ${#versions[@]} -eq 0 ]; then
-	versions=( */ )
-fi
-versions=( "${versions[@]%/}" )
+#versions=( "$@" )
+#if [ ${#versions[@]} -eq 0 ]; then
+#	versions=( */ )
+#fi
+#versions=( "${versions[@]%/}" )
+versions=( 2.4 5 )
 
 travisEnv=
 for version in "${versions[@]}"; do
@@ -75,4 +76,4 @@ for version in "${versions[@]}"; do
 done
 
 travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"
-echo "$travis" > .travis.yml
+#echo "$travis" > .travis.yml


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch-docker, especially https://github.com/elastic/elasticsearch-docker/tree/6.3.  The `Dockerfile-oss` included here was specifically generated from https://github.com/elastic/elasticsearch-docker/commit/0a5c00cd49def9246c1aa3a6d4ec50966c5bcad9, and the result of the converted build is almost identical to the artifacts published at `docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3` (used `docker save` and `diffoscope` to compare -- probably would be even better to use `docker export` to get a cleaner flat comparison).