### PR TITLE
Update URLs to new repo

### DIFF
--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -4,7 +4,7 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.0@sha256:e9cba8dec2df88a1af911787f05cf5200a5d9d64e4517f64deb8bafc6e96176f
 
 # The upstream image was built by:
-#   https://github.com/elastic/elasticsearch-docker/tree/6.6.0
+#   https://github.com/elastic/dockerfiles/tree/v6.6.0/elasticsearch
 
 # For a full list of supported images and tags visit https://www.docker.elastic.co
 

--- a/Dockerfile-upstream.template
+++ b/Dockerfile-upstream.template
@@ -4,7 +4,7 @@
 FROM %%UPSTREAM_IMAGE_DIGEST%%
 
 # The upstream image was built by:
-#   https://github.com/elastic/elasticsearch-docker/tree/%%ELASTICSEARCH_VERSION%%
+#   https://github.com/elastic/dockerfiles/tree/v%%ELASTICSEARCH_VERSION%%/elasticsearch
 
 # For a full list of supported images and tags visit https://www.docker.elastic.co
 


### PR DESCRIPTION
cc @jethr0null @jarpy

Does this look right?  Is this reasonable?

There is a slight diff in what I build there vs what I get when I pull the current image, but it's _just_ a newer OpenJDK release which is IMO totally reasonable:

```diff
$ diff -u <(docker history --no-trunc --format '{{ .CreatedBy }}' docker.elastic.co/elasticsearch/elasticsearch:6.6.0@sha256:e9cba8dec2df88a1af911787f05cf5200a5d9d64e4517f64deb8bafc6e96176f) <(docker history --no-trunc --format '{{ .CreatedBy }}' 400e4fd115e6)
--- /dev/fd/63	2019-02-07 15:13:44.697083633 -0800
+++ /dev/fd/62	2019-02-07 15:13:44.697083633 -0800
@@ -9,8 +9,8 @@
 /bin/sh -c #(nop) WORKDIR /usr/share/elasticsearch
 /bin/sh -c groupadd -g 1000 elasticsearch &&     adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch &&     chmod 0775 /usr/share/elasticsearch &&     chgrp 0 /usr/share/elasticsearch
 /bin/sh -c yum update -y &&     yum install -y nc unzip wget which &&     yum clean all
-/bin/sh -c #(nop) COPY dir:0313ee5e5effe3f9ca896090497c65d3c82c1dcbc241dc04f2bbb4e009e2ee97 in /opt/jdk-11.0.1
-/bin/sh -c #(nop)  ENV JAVA_HOME=/opt/jdk-11.0.1
+/bin/sh -c #(nop) COPY dir:a896d335b229294e400ed86b7cb0ad8cb244ea8d4dfa66fc95013d7e095fa1fc in /opt/jdk-11.0.2
+/bin/sh -c #(nop)  ENV JAVA_HOME=/opt/jdk-11.0.2
 /bin/sh -c #(nop)  ENV ELASTIC_CONTAINER=true
 /bin/sh -c #(nop)  CMD ["/bin/bash"]
 /bin/sh -c #(nop)  LABEL org.label-schema.schema-version=1.0 org.label-schema.name=CentOS Base Image org.label-schema.vendor=CentOS org.label-schema.license=GPLv2 org.label-schema.build-date=20181205
```