### PR TITLE
Add ca-certificate to wget

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -24,9 +24,8 @@ RUN set -ex; \
 		ca-certificates \
 		gnupg \
 		openssl \
-		tar \
-	; \
-	\
+		tar ; \
+	apk update; apk add ca-certificates wget ; update-ca-certificates; \
 	wget -O elasticsearch.tar.gz "$ELASTICSEARCH_TARBALL"; \
 	\
 	if [ "$ELASTICSEARCH_TARBALL_SHA1" ]; then \


### PR DESCRIPTION
This image is officially deprecated in favor of [the `elasticsearch` image provided by elastic.co](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) which is available to pull via `docker.elastic.co/elasticsearch/elasticsearch:[version]` like `5.2.1`. This image will receive no further updates after 2017-06-20 (June 20, 2017). Please adjust your usage accordingly.

Elastic provides open-source support for Elasticsearch via the [elastic/elasticsearch GitHub repository](https://github.com/elastic/elasticsearch) and the Docker image via the [elastic/elasticsearch-docker GitHub repository](https://github.com/elastic/elasticsearch-docker), as well as community support via its [forums](https://discuss.elastic.co/c/elasticsearch).
