### PR TITLE
Temporary backfill of missed versions

### DIFF
--- a/7.17.11/Dockerfile
+++ b/7.17.11/Dockerfile
@@ -1,0 +1,17 @@
+# Elasticsearch 7.17.11
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.11@sha256:f16e76d9de2996b7b94fb67b7087cba1b1b9267a8837da3b431f9213d5f48792
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v7.17.11/elasticsearch
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v7.17.11:elasticsearch'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For Elasticsearch documentation visit https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/4916 for more details.

--- a/8.8.2/Dockerfile
+++ b/8.8.2/Dockerfile
@@ -1,0 +1,17 @@
+# Elasticsearch 8.8.2
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.8.2@sha256:ec03cfb360d7b0dc576fd8ae2ad2306b988a7dd461eba3fad69f9ef69ee602de
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v8.8.2/elasticsearch
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v8.8.2:elasticsearch'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For Elasticsearch documentation visit https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/4916 for more details.

--- a/8.9.0/Dockerfile
+++ b/8.9.0/Dockerfile
@@ -1,0 +1,17 @@
+# Elasticsearch 8.9.0
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.9.0@sha256:33d0cb2bb128ddcfbce810e2afd5a30d110ee21778e8805940c4d37f5ab80601
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v8.9.0/elasticsearch
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v8.9.0:elasticsearch'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For Elasticsearch documentation visit https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/4916 for more details.

--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,7 @@ for version in "${versions[@]}"; do
 	fi
 
 	fullVersion="$(
-		grep -P "^\Qv$rcVersion." <<<"$tags" \
+		grep -P "^\Qv$rcVersion" <<<"$tags" \
 			| grep $rcGrepV -E -- '-(alpha|beta|rc)' \
 			| tail -1
 	)"


### PR DESCRIPTION
This is just to fill in `7.17.11`, `8.8.2`, and `8.9.0`.

Once merged, we can open the revert PR immediately. Once the changes are referenced in `docker-library/official-images` we can merge the revert.

```diff
$ diff -u ../official-images/library/elasticsearch <(./generate-stackbrew-library.sh)
--- ../official-images/library/elasticsearch    2023-08-23 16:05:44.440405336 -0700
+++ /dev/fd/63  2023-08-23 16:05:49.040378139 -0700
@@ -4,11 +4,26 @@
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git

+Tags: 8.9.0
+Architectures: amd64, arm64v8
+GitCommit: ae7c373dd5eed001b3b9b3676a1897bad7a4a846
+Directory: 8.9.0
+
+Tags: 8.8.2
+Architectures: amd64, arm64v8
+GitCommit: ae7c373dd5eed001b3b9b3676a1897bad7a4a846
+Directory: 8.8.2
+
 Tags: 8.9.1
 Architectures: amd64, arm64v8
 GitCommit: eae769ae918ec760e5d21385d22298003914bd33
 Directory: 8

+Tags: 7.17.11
+Architectures: amd64, arm64v8
+GitCommit: ae7c373dd5eed001b3b9b3676a1897bad7a4a846
+Directory: 7.17.11
+
 Tags: 7.17.12
 Architectures: amd64, arm64v8
 GitCommit: 5fe5a426ca33ac9869500cf87e6e4a14d7b1f9e5
```